### PR TITLE
Replaced token.bufferDelta with token.value.length

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -29,11 +29,11 @@ function extractRange(path, editor) {
           token.value === path[pathIndex]) {
         pathIndex++;
         if (pathIndex >= path.length) {
-          foundRange = [[lineNumber, offset], [lineNumber, offset + token.bufferDelta]]
+          foundRange = [[lineNumber, offset], [lineNumber, offset + token.value.length]]
           return;
         }
       }
-      offset += token.bufferDelta;
+      offset += token.value.length;
     });
     if (foundRange) {
       return foundRange;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository": "https://github.com/AtomLinter/linter-swagger",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.9.0 <2.0.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Fixes #26 for Atom 1.9.0 and greater; however, breaks compatibility with older versions of Atom. It may be desirable to test for `bufferDelta` vs `value.length` (not sure if the latter was/is available in earlier versions of Atom).

Here's the Atom commit that dropped `bufferDelta`: https://github.com/atom/atom/commit/544b75c7b0829be2ee6ff5caeffc97ae54d12c2e#diff-9113d52e8bbcf6fa618b1db8d18ea3f9