### PR TITLE
Update validator to use atom-linter.rangeFromLineNumber

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -2,6 +2,7 @@
 
 import SwaggerParser from 'swagger-parser';
 import _, { flatten } from 'lodash';
+import { rangeFromLineNumber } from 'atom-linter';
 
 function tokenizedLineForRow(editor, lineNumber) {
   return editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(lineNumber);
@@ -19,7 +20,6 @@ function extractRange(path, editor) {
   // remove numeric indexes
   var path = path.filter((str) => isNaN(str));
   while (true) {
-    let offset = 0;
     let tokenizedLine = tokenizedLineForRow(editor, lineNumber);
     if (typeof tokenizedLine === "undefined") {
       break;
@@ -29,11 +29,10 @@ function extractRange(path, editor) {
           token.value === path[pathIndex]) {
         pathIndex++;
         if (pathIndex >= path.length) {
-          foundRange = [[lineNumber, offset], [lineNumber, offset + token.bufferDelta]]
+          foundRange = rangeFromLineNumber(editor, lineNumber);
           return;
         }
       }
-      offset += token.bufferDelta;
     });
     if (foundRange) {
       return foundRange;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.6.1",
     "swagger-parser": "^3.4.0"

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -65,7 +65,7 @@ describe('The Swagger provider for Linter', () => {
       it('verifies the message', () => {
         waitsForPromise(() => {
           return lint(editor).then(messages => {
-            console.log(messages);
+            console.log(JSON.stringify(messages));
             expect(messages[0].type).toBeDefined();
             expect(messages[0].type).toEqual('Error');
             expect(messages[0].text).toBeDefined();


### PR DESCRIPTION
Fixes #26 in the way suggested by @Arcanemagus in #27.

Tested in Atom 1.11.2, but should work in earlier versions