### PR TITLE
Updates and bug fixes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,24 +1,25 @@
-'use babel'
+'use babel';
 
-import { tryValidate } from './validator';
 import { install } from 'atom-package-deps';
+import tryValidate from './validator';
 
 export default {
   activate() {
     this.scopes = ['source.json', 'source.yaml'];
     install('linter-swagger');
   },
+
   deactivate() {
   },
+
   provideLinter() {
     const provider = {
-      name: "SwaggerParser",
+      name: 'SwaggerParser',
       grammarScopes: this.scopes,
       scope: 'file',
       lintOnFly: true,
-      lint: tryValidate
-    }
+      lint: tryValidate,
+    };
     return provider;
-  }
-
-}
+  },
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,13 +13,12 @@ export default {
   },
 
   provideLinter() {
-    const provider = {
+    return {
       name: 'SwaggerParser',
       grammarScopes: this.scopes,
       scope: 'file',
       lintOnFly: true,
       lint: tryValidate,
     };
-    return provider;
   },
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,4 +1,4 @@
-'use babel'
+'use babel';
 
 import SwaggerParser from 'swagger-parser';
 import _, { flatten } from 'lodash';
@@ -8,38 +8,47 @@ function tokenizedLineForRow(editor, lineNumber) {
 }
 
 function checkTokenScope(scopes) {
-  return scopes.indexOf("entity.name.tag.yaml") >= 0 ||
-    scopes.indexOf("meta.structure.dictionary.json") >= 0;
+  return scopes.indexOf('entity.name.tag.yaml') >= 0 ||
+    scopes.indexOf('meta.structure.dictionary.json') >= 0;
 }
 
-function extractRange(path, editor) {
-  let lineNumber = 0,
-      pathIndex = 0,
-      foundRange;
+function extractRange(givenPath, editor) {
+  let lineNumber = 0;
+  let pathIndex = 0;
+  let foundRange;
+  const maxLine = editor.getLineCount();
   // remove numeric indexes
-  var path = path.filter((str) => isNaN(str));
-  while (true) {
+  const path = givenPath.filter(str => isNaN(str));
+
+  const checkLineTokens = (tokens) => {
     let offset = 0;
-    let tokenizedLine = tokenizedLineForRow(editor, lineNumber);
-    if (typeof tokenizedLine === "undefined") {
-      break;
-    }
-    tokenizedLine.tokens.forEach((token) => {
+    tokens.forEach((token) => {
       if (checkTokenScope(token.scopes) &&
           token.value === path[pathIndex]) {
-        pathIndex++;
+        pathIndex += 1;
         if (pathIndex >= path.length) {
-          foundRange = [[lineNumber, offset], [lineNumber, offset + token.bufferDelta]]
+          foundRange = [[lineNumber, offset], [lineNumber, offset + token.bufferDelta]];
           return;
         }
       }
       offset += token.bufferDelta;
     });
+  };
+
+  while (lineNumber <= maxLine) {
+    const tokenizedLine = tokenizedLineForRow(editor, lineNumber);
+    if (typeof tokenizedLine === 'undefined') {
+      break;
+    }
+    checkLineTokens(tokenizedLine.tokens);
     if (foundRange) {
       return foundRange;
     }
-    lineNumber++;
+    lineNumber += 1;
   }
+
+  // Unable to determine the range for some reason
+  return null;
 }
 
 function canValidate(path, text) {
@@ -48,54 +57,54 @@ function canValidate(path, text) {
 }
 
 function errorsToLinterMessages(err, path, editor) {
-  var errObj = err.toJSON();
+  const errObj = err.toJSON();
   if (!errObj.details) {
     return Promise.resolve([{
-      type: "Error",
+      type: 'Error',
       text: errObj.message,
-      filePath: path
+      filePath: path,
     }]);
   }
   return Promise.all(errObj.details.map((detail) => {
-    if (detail.code === "ONE_OF_MISSING" && detail.inner) {
-      let errors = _(detail.inner).map((innerDetail) => {
-        return {
-          type: "Error",
+    if (detail.code === 'ONE_OF_MISSING' && detail.inner) {
+      const errors = _(detail.inner).map(innerDetail => (
+        {
+          type: 'Error',
           text: innerDetail.message,
           filePath: path,
-          range: extractRange(innerDetail.path, editor)
-        };
-      }).valueOf();
+          range: extractRange(innerDetail.path, editor),
+        }
+      )).valueOf();
       return Promise.resolve(errors);
     }
     return Promise.resolve({
-      type: "Error",
+      type: 'Error',
       text: detail.message,
       filePath: path,
-      range: extractRange(detail.path, editor)
+      range: extractRange(detail.path, editor),
     });
   }));
 }
 
-export function tryValidate(editor) {
-  let path = editor.getPath();
-  let text = editor.getText();
+export default function tryValidate(editor) {
+  const path = editor.getPath();
+  const text = editor.getText();
   if (!canValidate(path, text)) {
     return Promise.resolve([]);
   }
   return new Promise((resolve) => {
     SwaggerParser.validate(path, {
       validate: {
-        spec: true
-      }
+        spec: true,
+      },
     })
-      .then((api) => {
+      .then(() => {
         resolve([]);
       })
       .catch((err) => {
         errorsToLinterMessages(err, path, editor)
-          .then(function(arg) {
-            let linterMessages = flatten(arg).valueOf();
+          .then((arg) => {
+            const linterMessages = flatten(arg).valueOf();
             resolve(linterMessages);
           });
       });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -8,8 +8,8 @@ function tokenizedLineForRow(editor, lineNumber) {
 }
 
 function checkTokenScope(scopes) {
-  return scopes.indexOf('entity.name.tag.yaml') >= 0 ||
-    scopes.indexOf('meta.structure.dictionary.json') >= 0;
+  return scopes.includes('entity.name.tag.yaml') ||
+    scopes.includes('meta.structure.dictionary.json');
 }
 
 function extractRange(givenPath, editor) {
@@ -59,13 +59,13 @@ function canValidate(path, text) {
 function errorsToLinterMessages(err, path, editor) {
   const errObj = err.toJSON();
   if (!errObj.details) {
-    return Promise.resolve([{
+    return [{
       type: 'Error',
       text: errObj.message,
       filePath: path,
-    }]);
+    }];
   }
-  return Promise.all(errObj.details.map((detail) => {
+  return errObj.details.map((detail) => {
     if (detail.code === 'ONE_OF_MISSING' && detail.inner) {
       const errors = _(detail.inner).map(innerDetail => (
         {
@@ -75,38 +75,38 @@ function errorsToLinterMessages(err, path, editor) {
           range: extractRange(innerDetail.path, editor),
         }
       )).valueOf();
-      return Promise.resolve(errors);
+      return errors;
     }
-    return Promise.resolve({
+    return {
       type: 'Error',
       text: detail.message,
       filePath: path,
       range: extractRange(detail.path, editor),
-    });
-  }));
+    };
+  });
 }
 
-export default function tryValidate(editor) {
+export default async function tryValidate(editor) {
   const path = editor.getPath();
   const text = editor.getText();
   if (!canValidate(path, text)) {
-    return Promise.resolve([]);
+    return [];
   }
-  return new Promise((resolve) => {
-    SwaggerParser.validate(path, {
-      validate: {
-        spec: true,
-      },
-    })
-      .then(() => {
-        resolve([]);
-      })
-      .catch((err) => {
-        errorsToLinterMessages(err, path, editor)
-          .then((arg) => {
-            const linterMessages = flatten(arg).valueOf();
-            resolve(linterMessages);
-          });
-      });
-  });
+
+  const swaggerParserOpts = {
+    validate: {
+      // Validate against the Swagger 2.0 spec
+      // https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/options.md
+      spec: true,
+    },
+  };
+
+  try {
+    await SwaggerParser.validate(path, swaggerParserOpts);
+    return [];
+  } catch (err) {
+    const arg = errorsToLinterMessages(err, path, editor);
+    const linterMessages = flatten(arg).valueOf();
+    return linterMessages;
+  }
 }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -2,6 +2,7 @@
 
 import SwaggerParser from 'swagger-parser';
 import _, { flatten } from 'lodash';
+import { rangeFromLineNumber } from 'atom-linter';
 
 function tokenizedLineForRow(editor, lineNumber) {
   return editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(lineNumber);
@@ -63,6 +64,7 @@ function errorsToLinterMessages(err, path, editor) {
       type: 'Error',
       text: errObj.message,
       filePath: path,
+      range: rangeFromLineNumber(editor),
     }];
   }
   return errObj.details.map((detail) => {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -5,7 +5,7 @@ import _, { flatten } from 'lodash';
 import { rangeFromLineNumber } from 'atom-linter';
 
 function tokenizedLineForRow(editor, lineNumber) {
-  return editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(lineNumber);
+  return editor.tokenizedBuffer.tokenizedLineForRow(lineNumber);
 }
 
 function checkTokenScope(scopes) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -105,6 +105,10 @@ export default async function tryValidate(editor) {
     await SwaggerParser.validate(path, swaggerParserOpts);
     return [];
   } catch (err) {
+    if (editor.getText() !== text) {
+      // Editor contents have changed, tell Linter not to update messages
+      return null;
+    }
     const arg = errorsToLinterMessages(err, path, editor);
     const linterMessages = flatten(arg).valueOf();
     return linterMessages;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,7 +1,6 @@
 'use babel';
 
 import SwaggerParser from 'swagger-parser';
-import _, { flatten } from 'lodash';
 import { rangeFromLineNumber } from 'atom-linter';
 
 function tokenizedLineForRow(editor, lineNumber) {
@@ -69,7 +68,7 @@ function errorsToLinterMessages(err, path, editor) {
   }
   return errObj.details.map((detail) => {
     if (detail.code === 'ONE_OF_MISSING' && detail.inner) {
-      const errors = _(detail.inner).map(innerDetail => (
+      const errors = detail.inner.map(innerDetail => (
         {
           type: 'Error',
           text: innerDetail.message,
@@ -85,7 +84,7 @@ function errorsToLinterMessages(err, path, editor) {
       filePath: path,
       range: extractRange(detail.path, editor),
     };
-  });
+  })[0];
 }
 
 export default async function tryValidate(editor) {
@@ -111,8 +110,7 @@ export default async function tryValidate(editor) {
       // Editor contents have changed, tell Linter not to update messages
       return null;
     }
-    const arg = errorsToLinterMessages(err, path, editor);
-    const linterMessages = flatten(arg).valueOf();
+    const linterMessages = errorsToLinterMessages(err, path, editor);
     return linterMessages;
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
-    "lodash": "^4.6.1",
     "swagger-parser": "3.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,39 @@
       }
     }
   },
+  "scripts": {
+    "test": "apm test",
+    "lint": "eslint ."
+  },
   "dependencies": {
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.6.1",
     "swagger-parser": "^3.4.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.8.1",
+    "eslint-config-airbnb-base": "^9.0.0",
+    "eslint-plugin-import": "^2.0.1"
+  },
+  "eslintConfig": {
+    "extends": "airbnb-base",
+    "rules": {
+      "global-require": "off",
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "atom"
+          ]
+        }
+      ]
+    },
+    "env": {
+      "browser": true,
+      "node": true
+    },
+    "globals": {
+      "atom": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.6.1",
     "swagger-parser": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.6.1",
-    "swagger-parser": "^3.4.0"
+    "swagger-parser": "3.4.1"
   },
   "devDependencies": {
     "eslint": "^3.8.1",

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    jasmine: true,
+    atomtest: true
+  }
+};

--- a/spec/fixtures/anyof.yaml
+++ b/spec/fixtures/anyof.yaml
@@ -1,0 +1,26 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: Invalid API
+
+paths:
+  /users:
+    get:
+      responses:
+        default:
+          description:  hello world
+          schema:
+            anyOf:                  # <--- "anyOf" is not supported by Swagger 2.0.  Only "allOf" is supported.
+              - properties:
+                  firstName:
+                    type: string
+                  lastName:
+                    type: string
+              - properties:
+                  middleName:
+                    type: string
+              - properties:
+                  age:
+                    type: number
+
+# Source: https://github.com/BigstickCarpet/swagger-parser/blob/releases/4.0.0/test/specs/validate-schema/invalid/anyof.yaml

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -1,93 +1,86 @@
 'use babel';
 
 import * as path from 'path';
+import { provideLinter } from '../lib/main';
+
+const lint = provideLinter().lint;
+
+const petstoreJSONPath = path.join(__dirname, 'fixtures', 'petstore.json');
+const petstoreYAMLPath = path.join(__dirname, 'fixtures', 'petstore.yaml');
+const petstoreBadref = path.join(__dirname, 'fixtures', 'petstore-badref.yaml');
 
 describe('The Swagger provider for Linter', () => {
-  const lint = require(path.join('..', 'lib', 'main.js')).provideLinter().lint;
-
   describe('linting JSON files', () => {
-
     beforeEach(() => {
       atom.workspace.destroyActivePaneItem();
       waitsForPromise(() => {
         atom.packages.activatePackage('linter-swagger');
         return atom.packages.activatePackage('language-json').then(() =>
-          atom.workspace.open(path.join(__dirname, 'fixtures', 'petstore.json'))
+          atom.workspace.open(petstoreJSONPath)
         );
       });
     });
 
     it('finds nothing wrong with valid file', () => {
-      waitsForPromise(() => {
-        const goodFile = path.join(__dirname, 'fixtures', 'petstore.json');
-        return atom.workspace.open(goodFile).then(editor => {
-          return lint(editor).then(messages => {
-            expect(messages.length).toEqual(0);
-          });
-        });
-      });
+      waitsForPromise(() =>
+        atom.workspace.open(petstoreJSONPath).then(editor =>
+          lint(editor).then(messages =>
+            expect(messages.length).toEqual(0)
+          )
+        )
+      );
     });
-
   });
 
   describe('linting YAML files', () => {
-
     beforeEach(() => {
       atom.workspace.destroyActivePaneItem();
       waitsForPromise(() => {
         atom.packages.activatePackage('linter-swagger');
         return atom.packages.activatePackage('language-yaml').then(() =>
-          atom.workspace.open(path.join(__dirname, 'fixtures', 'petstore.yaml'))
+          atom.workspace.open(petstoreYAMLPath)
         );
       });
     });
 
     describe('checks a file with issues', () => {
       let editor = null;
-      const badFile = path.join(__dirname, 'fixtures', 'petstore-badref.yaml');
 
       beforeEach(() => {
-        waitsForPromise(() => {
-          return atom.workspace.open(badFile).then(openEditor => {
+        waitsForPromise(() =>
+          atom.workspace.open(petstoreBadref).then((openEditor) => {
             editor = openEditor;
-          });
-        });
+          })
+        );
       });
 
-      it('finds at least one message', () => {
-        waitsForPromise(() => {
-          return lint(editor).then(messages => {
-            expect(messages.length).toBeGreaterThan(0);
-          });
-        });
-      });
+      it('finds at least one message', () =>
+        waitsForPromise(() =>
+          lint(editor).then(messages =>
+            expect(messages.length).toBeGreaterThan(0)
+          )
+        )
+      );
 
-      it('verifies the message', () => {
-        waitsForPromise(() => {
-          return lint(editor).then(messages => {
-            console.log(messages);
-            expect(messages[0].type).toBeDefined();
-            expect(messages[0].type).toEqual('Error');
+      it('verifies the message', () =>
+        waitsForPromise(() =>
+          lint(editor).then((messages) => {
+            expect(messages[0].type).toBe('Error');
             expect(messages[0].text).toBeDefined();
-            expect(messages[0].filePath).toBeDefined();
-            expect(messages[0].filePath).toMatch(/.+petstore\-badref\.yaml$/);
-          });
-        });
-      });
+            expect(messages[0].filePath).toBe(petstoreBadref);
+          })
+        )
+      );
     });
 
-    it('finds nothing wrong with valid file', () => {
-      waitsForPromise(() => {
-        const goodFile = path.join(__dirname, 'fixtures', 'petstore.yaml');
-        return atom.workspace.open(goodFile).then(editor => {
-          return lint(editor).then(messages => {
-            expect(messages.length).toEqual(0);
-          });
-        });
-      });
-    });
-
+    it('finds nothing wrong with a valid file', () =>
+      waitsForPromise(() =>
+        atom.workspace.open(petstoreYAMLPath).then(editor =>
+          lint(editor).then((messages) => {
+            expect(messages.length).toBe(0);
+          })
+        )
+      )
+    );
   });
-
-
 });

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -58,23 +58,29 @@ describe('The Swagger provider for Linter', () => {
         );
       });
 
-      it('finds at least one message', () =>
+      it('finds one message', () =>
         waitsForPromise(() =>
           lint(editor).then(messages =>
-            expect(messages.length).toBeGreaterThan(0)
+            expect(messages.length).toBe(1)
           )
         )
       );
 
-      it('verifies the message', () =>
-        waitsForPromise(() =>
+      it('verifies the message', () => {
+        /* eslint-disable no-useless-escape */
+        const msgRegex = new RegExp('Error resolving \\$ref pointer ".+' +
+          '#\/definitions\/INVALIDREFERENCE"\\.\\s+' +
+          'Token "definitions" does not exist\\.', 'g');
+        /* eslint-enable no-useless-escape */
+        return waitsForPromise(() =>
           lint(editor).then((messages) => {
             expect(messages[0].type).toBe('Error');
-            expect(messages[0].text).toBeDefined();
+            expect(messages[0].text).toMatch(msgRegex);
             expect(messages[0].filePath).toBe(petstoreBadref);
+            expect(messages[0].range).toEqual([[0, 0], [0, 14]]);
           })
-        )
-      );
+        );
+      });
     });
 
     it('finds nothing wrong with a valid file', () =>

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -1,13 +1,13 @@
 'use babel';
 
-import * as path from 'path';
+import { join } from 'path';
 import { provideLinter } from '../lib/main';
 
 const lint = provideLinter().lint;
 
-const petstoreJSONPath = path.join(__dirname, 'fixtures', 'petstore.json');
-const petstoreYAMLPath = path.join(__dirname, 'fixtures', 'petstore.yaml');
-const petstoreBadref = path.join(__dirname, 'fixtures', 'petstore-badref.yaml');
+const petstoreJSONPath = join(__dirname, 'fixtures', 'petstore.json');
+const petstoreYAMLPath = join(__dirname, 'fixtures', 'petstore.yaml');
+const petstoreBadref = join(__dirname, 'fixtures', 'petstore-badref.yaml');
 
 describe('The Swagger provider for Linter', () => {
   describe('linting JSON files', () => {
@@ -17,9 +17,7 @@ describe('The Swagger provider for Linter', () => {
         Promise.all([
           atom.packages.activatePackage('linter-swagger'),
           atom.packages.activatePackage('language-json'),
-        ]).then(() =>
-          atom.workspace.open(petstoreJSONPath)
-        )
+        ])
       );
     });
 
@@ -41,9 +39,7 @@ describe('The Swagger provider for Linter', () => {
         Promise.all([
           atom.packages.activatePackage('linter-swagger'),
           atom.packages.activatePackage('language-yaml'),
-        ]).then(() =>
-          atom.workspace.open(petstoreYAMLPath)
-        )
+        ])
       );
     });
 

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -8,6 +8,7 @@ const lint = provideLinter().lint;
 const petstoreJSONPath = join(__dirname, 'fixtures', 'petstore.json');
 const petstoreYAMLPath = join(__dirname, 'fixtures', 'petstore.yaml');
 const petstoreBadref = join(__dirname, 'fixtures', 'petstore-badref.yaml');
+const anyOfPath = join(__dirname, 'fixtures', 'anyof.yaml');
 
 describe('The Swagger provider for Linter', () => {
   describe('linting JSON files', () => {
@@ -43,7 +44,7 @@ describe('The Swagger provider for Linter', () => {
       );
     });
 
-    describe('checks a file with issues', () => {
+    describe('checks a file with a single issue', () => {
       let editor = null;
 
       beforeEach(() => {
@@ -78,6 +79,26 @@ describe('The Swagger provider for Linter', () => {
         );
       });
     });
+
+    describe('checks a file with multiple issues', () =>
+      it('finds all the messages', () =>
+        waitsForPromise(() =>
+          atom.workspace.open(anyOfPath).then(editor =>
+            lint(editor).then((messages) => {
+              expect(messages[0].type).toBe('Error');
+              expect(messages[0].text).toBe("Data does not match any schemas from 'oneOf'");
+              expect(messages[0].filePath).toBe(anyOfPath);
+              expect(messages[0].range).toEqual([[11, 10], [11, 16]]);
+
+              expect(messages[1].type).toBe('Error');
+              expect(messages[1].text).toBe('Missing required property: $ref');
+              expect(messages[1].filePath).toBe(anyOfPath);
+              expect(messages[1].range).toEqual([[9, 8], [9, 15]]);
+            })
+          )
+        )
+      )
+    );
 
     it('finds nothing wrong with a valid file', () =>
       waitsForPromise(() =>

--- a/spec/linter-swagger-spec.js
+++ b/spec/linter-swagger-spec.js
@@ -13,19 +13,21 @@ describe('The Swagger provider for Linter', () => {
   describe('linting JSON files', () => {
     beforeEach(() => {
       atom.workspace.destroyActivePaneItem();
-      waitsForPromise(() => {
-        atom.packages.activatePackage('linter-swagger');
-        return atom.packages.activatePackage('language-json').then(() =>
+      waitsForPromise(() =>
+        Promise.all([
+          atom.packages.activatePackage('linter-swagger'),
+          atom.packages.activatePackage('language-json'),
+        ]).then(() =>
           atom.workspace.open(petstoreJSONPath)
-        );
-      });
+        )
+      );
     });
 
     it('finds nothing wrong with valid file', () => {
       waitsForPromise(() =>
         atom.workspace.open(petstoreJSONPath).then(editor =>
           lint(editor).then(messages =>
-            expect(messages.length).toEqual(0)
+            expect(messages.length).toBe(0)
           )
         )
       );
@@ -35,12 +37,14 @@ describe('The Swagger provider for Linter', () => {
   describe('linting YAML files', () => {
     beforeEach(() => {
       atom.workspace.destroyActivePaneItem();
-      waitsForPromise(() => {
-        atom.packages.activatePackage('linter-swagger');
-        return atom.packages.activatePackage('language-yaml').then(() =>
+      waitsForPromise(() =>
+        Promise.all([
+          atom.packages.activatePackage('linter-swagger'),
+          atom.packages.activatePackage('language-yaml'),
+        ]).then(() =>
           atom.workspace.open(petstoreYAMLPath)
-        );
-      });
+        )
+      );
     });
 
     describe('checks a file with issues', () => {


### PR DESCRIPTION
Many small changes and fixes around the codebase including:

* Bring in ESLint, as well as `eslint-config-airbnb-base` so a consistent code style and error checking can be enforced
* Pin `swagger-parser`, GreenKeeper will notify us on new releases so a version of this updating users can be pushed out
* Fix the package activation in the specs, before this it was basically luck that it was working
* Remove the few instances of `lodash` in favor of native JS
* Utilize `async` / `await`
* Fix a race condition if the editor contents change before SwaggerParser returns.
* Expand the specs
  * Check the range and message for the simple file
  * Add specs testing the multi-message code path