### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
     - os: linux
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      env: ATOM_CHANNEL=stable
-
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
@@ -32,10 +29,12 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:
     - build-essential
-    - git
-    - libgnome-keyring-dev
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Update the Travis CI configuration to:
* Remove OS X testing as there is no specific need here for it.
* Update to the Trusty image for Linux
* Update APT package dependencies