### PR TITLE
Handle undefined ranges

### DIFF
--- a/lib/range-util.js
+++ b/lib/range-util.js
@@ -83,7 +83,12 @@ export default function populateRangesForErrors(errors, text) {
 
   errors.forEach((error) => {
     if (error.path && error.path.length) {
-      const range = findRangeRecursive(docRoot, error.path.slice(0));
+      let range = findRangeRecursive(docRoot, error.path.slice(0));
+      if (!range) {
+        // If findRangeRecursive wasn't able to determine a range, set it to the
+        // entire first line of the file.
+        range = [[0, 0], [0, Infinity]];
+      }
       error.range = range; // eslint-disable-line no-param-reassign
     }
   });


### PR DESCRIPTION
If the `findRangeRecursive` function was unable to determine a range for an error message, use the entire first line of the file as the range reported. This isn't exactly ideal, but doing this in the same way errors like this are handled in other providers would require a large rewrite.

Originally reported in https://github.com/AtomLinter/atom-minimap-linter/issues/25 that this was an issue.