### PR TITLE
Lint OpenAPI specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package will automatically install `linter` if that is missing.
 
 ## Usage
 
-This package will automatically lint YAML and JSON files that have a `swagger` field
+This package will automatically lint YAML and JSON files that have a `swagger` or `openapi` field
 with a version number value, in accordance to the [Swagger spec](http://swagger.io/specification/).
 
 ## License

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ let populateRangesForErrors;
 const idleCallbacks = new Set();
 
 function canValidate(text) {
-  return text.length > 8 && /"?swagger"?\s*:\s*['"]\d+\.\d+['"]/g.test(text);
+  return text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]\d+\.\d+(.\d+)?['"]/g.test(text);
 }
 
 function errorsToLinterMessages(err, path, text) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,6 +37,7 @@ function loadDependencies() {
 }
 
 export default {
+  canValidate,
   activate() {
     let depsCallbackID;
     const linterSwaggerDeps = () => {

--- a/spec/js-spec.js
+++ b/spec/js-spec.js
@@ -1,7 +1,7 @@
 'use babel';
 
 // eslint-disable-next-line no-unused-vars
-import { it } from 'jasmine-fix';
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { canValidate } from '../lib/main';
 
 describe('Test JS code', () => {

--- a/spec/js-spec.js
+++ b/spec/js-spec.js
@@ -1,0 +1,17 @@
+'use babel';
+
+// eslint-disable-next-line no-unused-vars
+import { it } from 'jasmine-fix';
+import { canValidate } from '../lib/main';
+
+describe('Test JS code', () => {
+  it('Validates Swagger files', async () => {
+    expect(canValidate('swagger: "2.0"')).toBe(true);
+  });
+  it('Validates OpenAPI files', async () => {
+    expect(canValidate('openapi: "3.0.1"')).toBe(true);
+  });
+  it('Does not validate non-Swagger/OpenAPI files', async () => {
+    expect(canValidate('notaspec: "3.0.1"')).toBe(false);
+  });
+});


### PR DESCRIPTION
OpenAPI specs are specified using `openapi` instead of `swagger`: https://swagger.io/specification/#oasDocument

I manually tested the regex, but didn't formalize it in a test spec:
```
$ node
> text='swagger: "2.0"'; text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]\d+\.\d+(.\d+)?['"]/g.test(text)
true
> text='openapi: "3.0.1"'; text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]\d+\.\d+(.\d+)?['"]/g.test(text)
true
> text='notaspec: "3.0.1"'; text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]\d+\.\d+(.\d+)?['"]/g.test(text)
false
>
```