### PR TITLE
Don't require quotes around version

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ let populateRangesForErrors;
 const idleCallbacks = new Set();
 
 function canValidate(text) {
-  return text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]\d+\.\d+(.\d+)?['"]/g.test(text);
+  return text.length > 8 && /"?(swagger|openapi)"?\s*:\s*['"]?\d+\.\d+(.\d+)?['"]?/g.test(text);
 }
 
 function errorsToLinterMessages(err, path, text) {

--- a/spec/fixtures/openapi.yaml
+++ b/spec/fixtures/openapi.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Open API Sample
+  version: 1.0.0
+paths:
+  /todos:
+    get:
+      description: "Returns all todo items"
+      responses:
+        200:
+          description: "A list of todo items"
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: strin
+                  format: uuid
+                name:
+                  type: string

--- a/spec/yaml-files-spec.js
+++ b/spec/yaml-files-spec.js
@@ -19,6 +19,30 @@ describe('Linting YAML files', () => {
     await atom.packages.activatePackage('linter-swagger');
   });
 
+  it('Handles no quotes around version', async () => {
+    const OPENAPI = join(__dirname, 'fixtures', 'openapi.yaml');
+    const editor = await atom.workspace.open(OPENAPI);
+    const messages = await lint(editor);
+
+    expect(messages.length).toEqual(2);
+    expect(messages[0]).toEqual({
+      severity: 'error',
+      excerpt: 'Additional properties not allowed: schema',
+      location: {
+        file: OPENAPI,
+        position: [[11, 10], [11, 16]],
+      },
+    });
+    expect(messages[1]).toEqual({
+      severity: 'error',
+      excerpt: 'Missing required property: $ref',
+      location: {
+        file: OPENAPI,
+        position: [[11, 10], [11, 16]],
+      },
+    });
+  });
+
   it('Handles correct input with no errors', async () => {
     const PETSTORE = join(__dirname, 'fixtures', 'petstore.yaml');
     const editor = await atom.workspace.open(PETSTORE);


### PR DESCRIPTION
YAML files don't require quotes around the version string, it's only recommended. Loosen up the restrictions to allow linting on these files.

Fixes #79.